### PR TITLE
Fix comment clarifying CLI argument behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ async function main() {
       .name('music-sorter')
       .description('Sort and organize music files')
       .version('1.0.0')
-      .allowExcessArguments(false); // This prevents excess arguments errors
+      // Disallow extra arguments so unexpected inputs cause an error
+      .allowExcessArguments(false);
     
     setupCommands(program);
     


### PR DESCRIPTION
## Summary
- correct comment describing `allowExcessArguments(false)` behavior in `src/index.ts`

## Testing
- `npm run build`
- `bash run-all-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841df22ea44832392a157337be1b6e8