### PR TITLE
Refactor sorting logic

### DIFF
--- a/src/commands/sort-command.ts
+++ b/src/commands/sort-command.ts
@@ -6,6 +6,7 @@ import { FileOperations } from '../utils/file-operations';
 import { PATHS } from '../config/constants';
 import { logger } from '../utils/logger';
 import { settingsManager } from '../config/settings-manager';
+import { SortOptions, SortPattern } from '../models/music-file';
 
 export function sortCommand(program: Command): void {
   program
@@ -50,27 +51,16 @@ export function sortCommand(program: Command): void {
         logger.info('Extracting metadata...');
         const musicFiles = await metadataService.extractMetadata(files);
         logger.info(`Processed ${musicFiles.length} music files.`);
-        
-        switch (pattern) {
-          case 'artist':
-            await musicSorter.sortByArtist(musicFiles, copyMode);
-            break;
-          case 'album-artist':
-            await musicSorter.sortByAlbumArtist(musicFiles, copyMode);
-            break;
-          case 'album':
-            await musicSorter.sortByAlbum(musicFiles, copyMode);
-            break;
-          case 'genre':
-            await musicSorter.sortByGenre(musicFiles, copyMode);
-            break;
-          case 'year':
-            await musicSorter.sortByYear(musicFiles, copyMode);
-            break;
-          default:
-            logger.error(`Unknown pattern: ${pattern}`);
-        }
-        
+
+        const sortOptions: SortOptions = {
+          pattern: pattern as SortPattern,
+          copyMode,
+          nestedStructure: true,
+          includeArtistInAlbumFolder: true
+        };
+
+        await musicSorter.sortFiles(musicFiles, sortOptions);
+
         logger.success('Sorting complete!');
       } catch (error) {
         logger.error('Error during sorting:', error as Error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,7 @@ import { MusicSorter } from '../core/sorter';
 import { FileOperations } from '../utils/file-operations';
 import { MetadataService } from '../services/metadata-service';
 import { PATHS, SUPPORTED_EXTENSIONS } from '../config/constants';
+import { SortOptions, SortPattern } from '../models/music-file';
 import { logger } from '../utils/logger';
 import { settingsManager } from '../config/settings-manager';
 
@@ -130,28 +131,16 @@ export async function startServer(port: number = 3000): Promise<void> {
       
       const musicFiles = await metadataService.extractMetadata(files);
       logger.info(`Processing ${musicFiles.length} music files`);
-      
-      // Perform sorting based on pattern
-      switch (pattern) {
-        case 'artist':
-          await musicSorter.sortByArtist(musicFiles, copy);
-          break;
-        case 'album-artist':
-          await musicSorter.sortByAlbumArtist(musicFiles, copy);
-          break;
-        case 'album':
-          await musicSorter.sortByAlbum(musicFiles, copy);
-          break;
-        case 'genre':
-          await musicSorter.sortByGenre(musicFiles, copy);
-          break;
-        case 'year':
-          await musicSorter.sortByYear(musicFiles, copy);
-          break;
-        default:
-          throw new Error(`Unknown pattern: ${pattern}`);
-      }
-      
+
+      const sortOptions: SortOptions = {
+        pattern: pattern as SortPattern,
+        copyMode: !!copy,
+        nestedStructure: true,
+        includeArtistInAlbumFolder: true
+      };
+
+      await musicSorter.sortFiles(musicFiles, sortOptions);
+
       logger.success('Sorting operation completed successfully');
       res.json({ success: true, message: 'Sorting complete' });
     } catch (error) {


### PR DESCRIPTION
## Summary
- remove switch-cases from sort command and server
- use `sortFiles` with typed options

## Testing
- `pnpm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841ef3021c48323b9b1f31eea108cb5