### PR TITLE
Refactor option handling

### DIFF
--- a/src/commands/sort-command.ts
+++ b/src/commands/sort-command.ts
@@ -6,6 +6,8 @@ import { FileOperations } from '../utils/file-operations';
 import { PATHS } from '../config/constants';
 import { logger } from '../utils/logger';
 import { settingsManager } from '../config/settings-manager';
+import { SortOptions } from '../models/music-file';
+import { buildSortOptions } from '../utils/sort-utils';
 
 export function sortCommand(program: Command): void {
   program
@@ -50,27 +52,11 @@ export function sortCommand(program: Command): void {
         logger.info('Extracting metadata...');
         const musicFiles = await metadataService.extractMetadata(files);
         logger.info(`Processed ${musicFiles.length} music files.`);
-        
-        switch (pattern) {
-          case 'artist':
-            await musicSorter.sortByArtist(musicFiles, copyMode);
-            break;
-          case 'album-artist':
-            await musicSorter.sortByAlbumArtist(musicFiles, copyMode);
-            break;
-          case 'album':
-            await musicSorter.sortByAlbum(musicFiles, copyMode);
-            break;
-          case 'genre':
-            await musicSorter.sortByGenre(musicFiles, copyMode);
-            break;
-          case 'year':
-            await musicSorter.sortByYear(musicFiles, copyMode);
-            break;
-          default:
-            logger.error(`Unknown pattern: ${pattern}`);
-        }
-        
+
+        const sortOptions: SortOptions = buildSortOptions(pattern, copyMode);
+
+        await musicSorter.sortFiles(musicFiles, sortOptions);
+
         logger.success('Sorting complete!');
       } catch (error) {
         logger.error('Error during sorting:', error as Error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,8 @@ import { MusicSorter } from '../core/sorter';
 import { FileOperations } from '../utils/file-operations';
 import { MetadataService } from '../services/metadata-service';
 import { PATHS, SUPPORTED_EXTENSIONS } from '../config/constants';
+import { SortOptions } from '../models/music-file';
+import { buildSortOptions } from '../utils/sort-utils';
 import { logger } from '../utils/logger';
 import { settingsManager } from '../config/settings-manager';
 
@@ -130,28 +132,11 @@ export async function startServer(port: number = 3000): Promise<void> {
       
       const musicFiles = await metadataService.extractMetadata(files);
       logger.info(`Processing ${musicFiles.length} music files`);
-      
-      // Perform sorting based on pattern
-      switch (pattern) {
-        case 'artist':
-          await musicSorter.sortByArtist(musicFiles, copy);
-          break;
-        case 'album-artist':
-          await musicSorter.sortByAlbumArtist(musicFiles, copy);
-          break;
-        case 'album':
-          await musicSorter.sortByAlbum(musicFiles, copy);
-          break;
-        case 'genre':
-          await musicSorter.sortByGenre(musicFiles, copy);
-          break;
-        case 'year':
-          await musicSorter.sortByYear(musicFiles, copy);
-          break;
-        default:
-          throw new Error(`Unknown pattern: ${pattern}`);
-      }
-      
+
+      const sortOptions: SortOptions = buildSortOptions(pattern, !!copy);
+
+      await musicSorter.sortFiles(musicFiles, sortOptions);
+
       logger.success('Sorting operation completed successfully');
       res.json({ success: true, message: 'Sorting complete' });
     } catch (error) {

--- a/src/utils/sort-utils.ts
+++ b/src/utils/sort-utils.ts
@@ -1,0 +1,36 @@
+import { SortPattern, SortOptions } from '../models/music-file';
+
+/**
+ * Parse a sort pattern string and return the corresponding enum value.
+ * Returns null if the pattern is invalid.
+ */
+export function parseSortPattern(pattern: string): SortPattern | null {
+  switch (pattern) {
+    case SortPattern.ARTIST:
+    case SortPattern.ALBUM_ARTIST:
+    case SortPattern.ALBUM:
+    case SortPattern.GENRE:
+    case SortPattern.YEAR:
+      return pattern as SortPattern;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build a SortOptions object from provided parameters.
+ * Throws an error if the pattern is invalid.
+ */
+
+export function buildSortOptions(pattern: string, copyMode = false): SortOptions {
+  const parsed = parseSortPattern(pattern);
+  if (!parsed) {
+    throw new Error(`Unknown pattern: ${pattern}`);
+  }
+  return {
+    pattern: parsed,
+    copyMode,
+    nestedStructure: true,
+    includeArtistInAlbumFolder: true
+  };
+}


### PR DESCRIPTION
## Summary
- pull repetitive sorting option logic into `buildSortOptions`
- replace inline objects with the new helper in the command and server

## Testing
- `npm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6841ef3021c48323b9b1f31eea108cb5