### PR TITLE
Fix SortOptions pattern type

### DIFF
--- a/src/models/music-file.ts
+++ b/src/models/music-file.ts
@@ -67,7 +67,7 @@ export enum SortPattern {
 }
 
 export interface SortOptions {
-  pattern: SortPattern | string;
+  pattern: SortPattern;
   copyMode: boolean;
   nestedStructure: boolean;
   includeArtistInAlbumFolder: boolean;

--- a/src/tests/integration-test.ts
+++ b/src/tests/integration-test.ts
@@ -177,7 +177,7 @@ async function runIntegrationTest() {
     // Test with invalid pattern
     try {
       const invalidOptions: SortOptions = {
-        pattern: 'invalid-pattern' as SortPattern,
+        pattern: 'invalid-pattern' as unknown as SortPattern,
         copyMode: true,
         nestedStructure: true,
         includeArtistInAlbumFolder: true

--- a/src/tests/test-suite.ts
+++ b/src/tests/test-suite.ts
@@ -292,7 +292,7 @@ class MusicSorterTestSuite {
       
       // Test sorting by artist
       const artistSortOptions: SortOptions = {
-        pattern: 'artist',
+        pattern: SortPattern.ARTIST,
         copyMode: true,
         nestedStructure: true,
         includeArtistInAlbumFolder: true
@@ -319,7 +319,7 @@ class MusicSorterTestSuite {
       
       // Test sorting by album
       const albumSortOptions: SortOptions = {
-        pattern: 'album',
+        pattern: SortPattern.ALBUM,
         copyMode: true,
         nestedStructure: true,
         includeArtistInAlbumFolder: true
@@ -346,7 +346,7 @@ class MusicSorterTestSuite {
       // Test error handling
       try {
         await this.musicSorter.sortFiles(musicFiles, {
-          pattern: 'invalid' as any,
+          pattern: 'invalid' as unknown as SortPattern,
           copyMode: true,
           nestedStructure: true,
           includeArtistInAlbumFolder: true


### PR DESCRIPTION
## Summary
- require `SortPattern` for `SortOptions.pattern`
- update tests to use enum values and cast invalid cases appropriately

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684320bed7948323a450a6a504133346